### PR TITLE
[JBWS-4498][JBWS-4499] - Upgrade jakarta.xml.ws:jakarta.xml.ws-api from 3.0.1 to 4.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # jaxws-undertow-httpspi
 
-Undertow to JAXWS 2.2 HTTP SPI bridge.
+Undertow to Jakarta XML Web Services HTTP SPI bridge.
 Please review this [document](https://github.com/jbossws/jbossws-cxf/wiki/Sub%E2%80%90project-Releasing) before tagging and releasing.

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
   <artifactId>jaxws-undertow-httpspi</artifactId>
   <packaging>jar</packaging>
 
-  <name>JBoss Web Services - Undertow to JAXWS 2.2 HTTP SPI bridge</name>
-  <description>JBoss Web Services - Undertow to JAXWS 2.2 HTTP SPI bridge Jakarta Version</description>
+  <name>JBoss Web Services - Undertow to Jakarta XML Web Services HTTP SPI bridge</name>
+  <description>JBoss Web Services - Undertow to Jakarta XML Web Services HTTP SPI bridge Jakarta Version</description>
   <url>https://github.com/jbossws/jaxws-undertow-httpspi</url>
 
   <version>3.0.0.Final-SNAPSHOT</version>
@@ -34,10 +34,10 @@
     <nexus.staging.tag>jaxws-undertow-httpspi-${project.version}</nexus.staging.tag>
     <!-- Dependency versions -->
     <junit.version>4.13.2</junit.version>
-    <cxf.version>4.0.0</cxf.version>
+    <cxf.version>4.1.5</cxf.version>
     <servlet-api.version>5.0.0</servlet-api.version>
     <io.undertow.version>2.2.28.Final</io.undertow.version>
-    <jaxws.api.version>3.0.1</jaxws.api.version>
+    <jaxws.api.version>4.0.3</jaxws.api.version>
   </properties>
 
   <!-- licenses -->


### PR DESCRIPTION
Issues:
- https://redhat.atlassian.net/browse/JBWS-4498
- https://redhat.atlassian.net/browse/JBWS-4499

Apache CXF is updated too, since 4.0.x is no longer supported and jbossws-cxf aligned to 4.1.x already. 
Done in this very PR otherwise tests won't pass.